### PR TITLE
don't reference root in the startup screen

### DIFF
--- a/client-loop
+++ b/client-loop
@@ -33,7 +33,7 @@ msg="
   ${red}           ▝▀▀▀           ${reset}
 
 
-Plese enter your TiDB root password to log in to a client shell.
+Plese enter your TiDB password to log in to a client shell.
 
 "
 
@@ -46,7 +46,7 @@ if test "${MYSQL_PWD+defined}"; then
     fi
 else
     while true; do
-        if ! read -r -s -t "$PWTIMEOUT" -p 'TiDB root password: ' password; then
+        if ! read -r -s -t "$PWTIMEOUT" -p 'TiDB password: ' password; then
            err=1
            break
         fi


### PR DESCRIPTION
It seems that I can pass in -u user and that will override the existing
-u root.
The only problem is there is text stating "root".

It can be nice though to specify the user in the text as this does now.
Maybe we could look at the arguments or set an environment variable?